### PR TITLE
Fix: Notion API 429 오류 방지를 위한 재시도 및 요청 중복 제거

### DIFF
--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -20,9 +20,46 @@ const TAGS_CACHE = new Set<PostTag>();
 
 const api = new NotionAPI();
 
+const inflight = new Map<string, Promise<ExtendedRecordMap>>();
+
+async function fetchPageWithRetry(
+  pageId: string,
+  maxRetries = 3,
+): Promise<ExtendedRecordMap> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await api.getPage(pageId);
+    } catch (error: any) {
+      const is429 =
+        error?.message?.includes("429") ||
+        error?.statusCode === 429 ||
+        error?.code === 429;
+
+      if (is429 && attempt < maxRetries) {
+        const delay = Math.pow(2, attempt) * 1000 + Math.random() * 500;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        continue;
+      }
+      throw error;
+    }
+  }
+  throw new Error(`Failed to fetch page ${pageId} after ${maxRetries} retries`);
+}
+
+function deduplicatedFetch(pageId: string): Promise<ExtendedRecordMap> {
+  const existing = inflight.get(pageId);
+  if (existing) return existing;
+
+  const promise = fetchPageWithRetry(pageId).finally(() => {
+    inflight.delete(pageId);
+  });
+  inflight.set(pageId, promise);
+  return promise;
+}
+
 export const getPage = unstable_cache(
   async (pageId: string) => {
-    return await api.getPage(pageId);
+    return await deduplicatedFetch(pageId);
   },
   ["notion-page"],
   { revalidate: 600 }, // 10 minutes


### PR DESCRIPTION
## Summary
- Notion API `429 Too Many Requests` 오류 방지를 위해 exponential backoff 재시도 로직 추가 (최대 3회)
- 캐시 만료 시 동일 페이지에 대한 동시 요청을 deduplication하여 API 호출 횟수 감소

## Test plan
- [ ] `/post/[slug]` 페이지 정상 로딩 확인
- [ ] Sentry에서 429 오류 빈도 감소 모니터링

🤖 Generated with [Claude Code](https://claude.com/claude-code)