### PR TITLE
feat: notion.useViewIdFilter 옵션 추가 (Notion view 필터·정렬 위임)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ you can customize below information on `site.config.ts` (자세한 옵션 표는
 | `twitter` | `string \| undefined` | Twitter/X URL |
 | `threads` | `string \| undefined` | Threads URL |
 
+### `notion`
+
+| 키 | 타입 | 설명 |
+|----|------|------|
+| `blogPageId` | `string` | Notion DB 페이지 ID. `NOTION_BLOG_PAGE_ID` env로 주입 |
+| `viewId` | `string` | Notion view ID. `NOTION_VIEW_ID` env로 주입. URL의 `?v=...` 부분 |
+| `useViewIdFilter` | `boolean` | `true`로 두면 Notion view의 필터/정렬을 그대로 사용. 코드 측 `posts.useScheduled` 및 status==Public 필터는 비활성 (view에 위임). 기본 `false` |
+
+#### `useViewIdFilter` 동작
+
+| 값 | 동작 |
+|----|------|
+| `false` (기본) | 모든 포스트를 가져온 뒤 코드의 `posts.useScheduled`, `status==Public` 등으로 필터 |
+| `true` | Notion에서 만든 view의 결과만 사용. 정렬·필터·hidden 컬럼 모두 view에 따름. viewId가 잘못되면 자동으로 기본 동작으로 fallback (콘솔 경고 출력) |
+
+view를 직접 만들고 싶다면:
+1. Notion에서 블로그 DB 우상단 `+` → 새 view 추가 (필터/정렬 자유 설정)
+2. 해당 view를 연 상태에서 URL의 `?v=<viewId>` 부분 복사
+3. `NOTION_VIEW_ID` env에 저장
+4. `notion.useViewIdFilter`를 `true`로 토글
+
 ### `meta`
 
 `Next.js Metadata`를 그대로 받으며 다음 키가 추가됨.

--- a/site.config.ts
+++ b/site.config.ts
@@ -19,6 +19,10 @@ const CONFIG: Config = {
   notion: {
     blogPageId: process.env.NOTION_BLOG_PAGE_ID || "",
     viewId: process.env.NOTION_VIEW_ID || "",
+    // Notion view의 필터/정렬을 그대로 사용
+    // true: view 기준 결과만 사용. 코드 측 status/useScheduled 필터 비활성 (view에 위임)
+    // false: 모든 포스트 가져온 뒤 코드 옵션으로 필터 (기본)
+    useViewIdFilter: false,
   },
   // SEO/Metadata 전역 기본값
   meta: {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -15,6 +15,7 @@ type Profile = {
 type NotionConfig = {
   blogPageId: string;
   viewId: string;
+  useViewIdFilter: boolean;
 };
 
 type MetaConfig = Metadata & {

--- a/src/utils/notion.ts
+++ b/src/utils/notion.ts
@@ -20,7 +20,7 @@ import {
 import { getOptionColor } from "./color";
 import { getSiteConfig } from "./config";
 
-const { blogPageId } = getSiteConfig("notion");
+const { blogPageId, viewId, useViewIdFilter } = getSiteConfig("notion");
 const {
   useScheduled: useScheduledPosts,
   perPage: postsPerPage,
@@ -146,7 +146,22 @@ export async function getPosts(pageId: string = blogPageId) {
     };
 
   const schema = getSchema(pageContent.collection);
-  const pageList = getPostList(pageContent.block);
+
+  // useViewIdFilter=true 이고 viewId가 record map에 존재하면 view 결과로 대체.
+  // 그렇지 않으면(false 또는 viewId 누락/오류) 모든 page block을 끌어오고 코드 측 필터를 적용.
+  const viewList =
+    useViewIdFilter && viewId
+      ? getPostListByView(pageContent, viewId)
+      : null;
+
+  if (useViewIdFilter && viewId && viewList === null) {
+    console.warn(
+      `[notion] useViewIdFilter=true이지만 viewId='${viewId}'를 record map에서 찾지 못해 기본 동작으로 fallback합니다.`,
+    );
+  }
+
+  const usingView = viewList !== null;
+  const pageList = viewList ?? getPostList(pageContent.block);
 
   const posts: Posts = {
     schema: schema || {},
@@ -155,14 +170,19 @@ export async function getPosts(pageId: string = blogPageId) {
         ...page,
         attributes: getPostAttribute(page, schema || {}),
       }))
-      .filter(
-        (page) =>
-          page.attributes.slug.value &&
-          (page.attributes.status.value === PostStatus.Public ||
-            (process.env.NODE_ENV === "development" &&
-              page.attributes.status.value === PostStatus.Editing)),
-      )
+      // slug 누락된 row만 제외. 나머지 노출 규칙은 view 모드일 때 view에 위임.
       .filter((page) => {
+        if (!page.attributes.slug.value) return false;
+        if (usingView) return true;
+        const status = page.attributes.status.value;
+        return (
+          status === PostStatus.Public ||
+          (process.env.NODE_ENV === "development" &&
+            status === PostStatus.Editing)
+        );
+      })
+      .filter((page) => {
+        if (usingView) return true;
         if (!useScheduledPosts) return true;
         if (page.attributes.status.value !== PostStatus.Public) return true;
         const dateValue = page.attributes?.date?.value;
@@ -170,14 +190,17 @@ export async function getPosts(pageId: string = blogPageId) {
         const postDate = new Date(dateValue).getTime();
         if (Number.isNaN(postDate)) return true;
         return postDate <= Date.now();
-      })
-      .sort((a, b) => {
-        const aDate = +new Date(a?.attributes?.date?.value || 0);
-        const bDate = +new Date(b?.attributes?.date?.value || 0);
-
-        return bDate - aDate;
       }),
   };
+
+  // view 모드면 view의 정렬을 그대로 신뢰. 기본 모드는 작성일 desc로 직접 정렬.
+  if (!usingView) {
+    posts.blocks.sort((a, b) => {
+      const aDate = +new Date(a?.attributes?.date?.value || 0);
+      const bDate = +new Date(b?.attributes?.date?.value || 0);
+      return bDate - aDate;
+    });
+  }
 
   return posts;
 }
@@ -324,6 +347,29 @@ export function getPostList(block: BlockMap) {
     .filter((b): b is Block => !!b);
 
   return blocks.filter((b) => b.type === "page");
+}
+
+// 지정된 viewId의 collection_query 결과(필터/정렬 적용)를 그대로 페이지 블록 배열로 반환.
+// viewId가 record map에 없으면 null을 반환해 호출자가 fallback 처리하도록 함.
+export function getPostListByView(
+  record: ExtendedRecordMap,
+  targetViewId: string,
+): Block[] | null {
+  if (!targetViewId) return null;
+
+  const collection = unwrapRecord(Object.values(record.collection || {})[0]);
+  const collectionId = collection?.id;
+  if (!collectionId) return null;
+
+  const queryView = record.collection_query?.[collectionId]?.[targetViewId];
+  if (!queryView) return null;
+
+  const ids = queryView.collection_group_results?.blockIds;
+  if (!ids) return null;
+
+  return ids
+    .map((id) => unwrapRecord(record.block[id]))
+    .filter((b): b is Block => !!b && b.type === "page");
 }
 
 function unwrapRecord<T>(box: NotionMapBox<T> | undefined): T | undefined {


### PR DESCRIPTION
## Summary

`notion.useViewIdFilter` 옵션 추가. `true`로 설정 시 지정한 Notion view(`NOTION_VIEW_ID`)의 결과를 그대로 사용. 코드 측 status/스케줄 필터·작성일 정렬은 비활성화되고 view에 모두 위임 (replace 모델).

## 동작

| `useViewIdFilter` | 동작 |
|---|---|
| `false` (기본) | 모든 포스트 가져온 뒤 코드 옵션(`useScheduled`, status==Public)으로 필터, 작성일 desc 정렬 |
| `true` | view의 collection_query 결과만 사용. 정렬·필터·hidden 컬럼 모두 view에 따름 |

- viewId가 잘못/누락되면 자동으로 기본 동작으로 fallback (콘솔 경고)
- `getPage` 응답에 이미 모든 view 데이터가 들어 있어 추가 API 호출 없음

## Replace를 선택한 이유

`useViewIdFilter` 토글은 사용자의 명시적 의사 표현. AND 모델은 view 의도와 코드 필터가 충돌할 때 추적 어려움. Replace는 "view = 진실"이라 멘탈 모델 단순.

## 변경

- `src/types/index.d.ts`: `NotionConfig.useViewIdFilter` 추가
- `site.config.ts`: 기본값 `false` + 주석
- `src/utils/notion.ts`: `getPostListByView` 헬퍼 + `getPosts` 분기 (replace + fallback)
- `README.md`: `notion` 그룹 옵션 표 + view 설정 가이드

## Test plan

- [x] `yarn tsc --noEmit` 통과
- [x] dev 서버 (`useViewIdFilter: false`) 회귀 없음 (200 OK, 동일 포스트 노출)
- [ ] 사용자 검증: `useViewIdFilter: true` 토글 + 유효한 `NOTION_VIEW_ID` 환경에서 view의 정렬·필터가 사이트에 그대로 반영되는지
- [ ] 사용자 검증: `useViewIdFilter: true`인데 viewId 누락/오타일 때 기본 동작으로 fallback + 콘솔 경고 출력
