### PR TITLE
docs: README 한글/영문 분리 (한글 기본)

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -5,7 +5,7 @@
 [![DEMO](https://img.shields.io/badge/BLOG%20DEMO-2d55ff)](https://www.chipmunk-world.com/)
 
 - ✏️ Write your posts in Notion
-- ⚙️ Easy site configuration
+- ⚙️ Rich site options without touching code
 - 🎨 Theme customization powered by [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract)
 - 📊 Google Analytics support
 - 🤖 Sentry support

--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,218 @@
+# Notion Blog Project
+
+[한국어](./README.md) · [English](./README.en.md)
+
+[![DEMO](https://img.shields.io/badge/BLOG%20DEMO-2d55ff)](https://www.chipmunk-world.com/)
+
+- ✏️ Write your posts in Notion
+- ⚙️ Easy site configuration
+- 🎨 Theme customization powered by [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract)
+- 📊 Google Analytics support
+- 🤖 Sentry support
+
+<br />
+
+## 🚀 Getting Started
+
+![image](https://github.com/im-ian/notion-blog/assets/38205068/fdc98dfd-c6df-4f1e-9909-e756ee08b29b)
+
+Fork this repository and clone it to your workspace.
+
+![image](https://github.com/im-ian/notion-blog/assets/38205068/56ade899-23bd-4544-8625-154ecad129ae)
+
+Duplicate [this Notion template](https://imian.notion.site/7cdd2b347b734b7caeb754d8701a4b57?v=c9d11f25b61b4d249d45f3b4dde4c2f2&pvs=4) into your own workspace.
+
+![image](https://github.com/im-ian/notion-blog/assets/38205068/0dff2c40-8464-4140-92c2-f865e5067cf2)
+
+Find your own ![#f03c15](https://placehold.co/13x13/f03c15/f03c15.png) `NOTION_BLOG_PAGE_ID` and ![#1589F0](https://placehold.co/13x13/1589F0/1589F0.png) `NOTION_VIEW_ID`.
+
+![image](https://github.com/im-ian/notion-blog/assets/38205068/62d3c169-d47b-4e78-80d4-192fe446b1c6)
+
+Add the values above to Vercel `Environment Variables`.
+
+To enable Sentry error tracking, all four env vars below must be set.
+
+- `SENTRY_ORG`
+- `SENTRY_PROJECT`
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_DSN`
+
+`Sentry.init()` is activated only when all four are present.
+
+![image](https://github.com/im-ian/notion-blog/assets/38205068/47731fd6-e4b0-4bfa-a0b4-c9ef9471f409)
+
+Deploy on [Vercel](https://vercel.com/) and you're done.
+
+<br />
+
+## 💻 Development
+
+```shell
+cp .env.example .env
+```
+
+For local development, copy `.env.example` to `.env`, then run:
+
+```shell
+yarn && yarn dev
+# or
+npm install && npm dev
+```
+
+<br />
+
+## 🎨 Customize
+
+```ts
+import type { Config } from "@/types";
+
+const CONFIG: Config = {
+  profile: {
+    // utterances repo for comments (owner/repo). Comments disabled if empty.
+    repo: "im-ian/notion-blog",
+    github: "im-ian",
+  },
+  // ...
+};
+```
+
+You can adjust the following groups in `site.config.ts` (see option tables below).
+
+- profile
+- notion
+- meta (SEO)
+- site
+- theme
+- search
+- posts
+- comments
+- rss
+- footer
+
+### `profile`
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | `string` | Display name |
+| `profileImage` | `string \| undefined` | Avatar URL |
+| `bio` | `string \| undefined` | Short bio |
+| `repo` | `string \| undefined` | utterances GitHub repo (`owner/repo`). Comments disabled when omitted |
+| `github` | `string \| undefined` | GitHub username |
+| `linkedin` | `string \| undefined` | LinkedIn URL |
+| `instagram` | `string \| undefined` | Instagram URL |
+| `twitter` | `string \| undefined` | Twitter/X URL |
+| `threads` | `string \| undefined` | Threads URL |
+
+### `notion`
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `blogPageId` | `string` | Notion DB page ID. Provided via `NOTION_BLOG_PAGE_ID` env |
+| `viewId` | `string` | Notion view ID. Provided via `NOTION_VIEW_ID` env. The `?v=...` portion of the URL |
+| `useViewIdFilter` | `boolean` | When `true`, results from the chosen Notion view are used as-is. Code-side filters (`posts.useScheduled`, `status==Public`) are bypassed (delegated to the view). Default `false` |
+
+#### `useViewIdFilter` behavior
+
+| Value | Behavior |
+|-------|----------|
+| `false` (default) | Fetch all posts and apply code filters (`posts.useScheduled`, `status==Public`) |
+| `true` | Use only the rows from the configured Notion view. Sorting, filtering, and hidden columns all follow the view. Falls back to default behavior automatically (with a console warning) if the view ID is invalid |
+
+To set up your own view:
+
+1. In your Notion DB, click `+` in the upper right and add a new view (configure filters/sorting freely)
+2. With that view open, copy the `?v=<viewId>` portion of the URL
+3. Save it as the `NOTION_VIEW_ID` env var
+4. Toggle `notion.useViewIdFilter` to `true`
+
+### `meta`
+
+Accepts `Next.js Metadata` directly, with the following extra keys.
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `siteUrl` | `string \| undefined` | Canonical domain. Used by sitemap, RSS, and the layout's `metadataBase`. Falls back to `process.env.SITE_URL` (one of the two is required in production) |
+| `ogImage` | `string \| undefined` | Default OG image. Also used as a fallback when a post has no thumbnail |
+
+### `site`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `lang` | `string` | `"ko"` | `<html lang>` value |
+| `title` | `string` | — | Site title, shown in the header |
+| `stickyProfile` | `boolean` | `false` | Sticky desktop sidebar profile while scrolling |
+
+### `theme`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `mode` | `"auto" \| "light" \| "dark"` | `"auto"` | Initial theme. `auto` follows OS settings. User toggle is persisted in localStorage and takes precedence afterwards |
+| `showToggle` | `boolean` | `true` | Show the dark-mode toggle button in the header. Set to `false` if you want to enforce `mode` |
+
+### `search`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `shortcut` | `boolean` | `true` | Enable the search keyboard shortcut (⌘/Ctrl+K) |
+| `scope` | `"title" \| "title+summary" \| "all"` | `"all"` | Matching scope for search. `all` covers title + summary + tags |
+| `showInHeader` | `boolean` | `true` | Show the search icon in the header (set to `false` for shortcut-only) |
+
+### `posts`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `perPage` | `number` | `10` | Number of posts per page (clamped to a minimum of 1) |
+| `paginationMode` | `"infinite" \| "numbered"` | `"infinite"` | `infinite` = infinite scroll (restores visible count and scroll position on back navigation). `numbered` = numbered pages + Prev/Next buttons; URL is `?page=N` |
+| `useScheduled` | `boolean` | `true` | When `true`, Public posts only appear after their date has passed (scheduled publishing) |
+| `showSummary` | `boolean` | `true` | Show post summary in the post card |
+| `showPrevNext` | `boolean` | `true` | Show adjacent (previous/next) post navigation at the bottom of post pages |
+| `dateFormat` | `string` | `"YYYY년 MM월 DD일"` | dayjs format token (e.g. `"YYYY-MM-DD"`, `"YYYY/MM/DD HH:mm"`) |
+| `showScrollProgress` | `boolean` | `true` | Show the scroll progress bar at the top of post pages |
+
+### `comments`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `use` | `boolean` | `true` | Show the utterances comments section (requires `profile.repo`) |
+
+### `rss`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `use` | `boolean` | `true` | Enable `/rss.xml`. Requires `meta.siteUrl` (or `SITE_URL` env). Returns 404 when `false` |
+
+### `footer`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `show` | `boolean` | `true` | Show the global site footer |
+| `text` | `string` | `"© ..."` | Footer text |
+
+```ts
+export const vars = createGlobalTheme(":root", {
+  // ...
+  color: {
+    white: "#fff",
+    black: "#333",
+    darkgray: "#2f3437",
+
+    "gray-50": "#f9fafb",
+    "gray-100": "#f3f4f6",
+    "gray-200": "#e5e7eb",
+    "gray-300": "#d1d5db",
+    "gray-400": "#9ca3af",
+    "gray-500": "#6b7280",
+    "gray-600": "#4b5563",
+    "gray-700": "#374151",
+    // ...
+  },
+});
+```
+
+To customize colors or sizes, edit `sprinkles.css.ts` or `vars.css.ts`.
+
+<br />
+
+## 📄 License
+
+Released under the [MIT License](./LICENSE). Feel free to fork and use it as your own blog.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![DEMO](https://img.shields.io/badge/BLOG%20DEMO-2d55ff)](https://www.chipmunk-world.com/)
 
 - ✏️ Notion으로 포스트 작성
-- ⚙️ 간단한 사이트 설정
+- ⚙️ 코드 수정 없이 다양한 사이트 옵션 설정
 - 🎨 [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract) 기반 테마 커스터마이징
 - 📊 Google Analytics 지원
 - 🤖 Sentry 지원

--- a/README.md
+++ b/README.md
@@ -1,80 +1,83 @@
 # Notion Blog Project
+
+[한국어](./README.md) · [English](./README.en.md)
+
 [![DEMO](https://img.shields.io/badge/BLOG%20DEMO-2d55ff)](https://www.chipmunk-world.com/)
 
-  - ✏️ Write your posts using Notion
-  - ⚙️ Easily configure site
-  - 🎨 Easily customize theme (with [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract))
-  - 📊 Google Analytics Support
-  - 🤖 Sentry Support
+- ✏️ Notion으로 포스트 작성
+- ⚙️ 간단한 사이트 설정
+- 🎨 [vanilla-extract](https://github.com/vanilla-extract-css/vanilla-extract) 기반 테마 커스터마이징
+- 📊 Google Analytics 지원
+- 🤖 Sentry 지원
 
 <br />
 
-## 🚀 Getting Started
+## 🚀 시작하기
 
 ![image](https://github.com/im-ian/notion-blog/assets/38205068/fdc98dfd-c6df-4f1e-9909-e756ee08b29b)
 
-Fork this repository and clone on your workspace.
+이 저장소를 fork해서 작업 공간에 clone합니다.
 
 ![image](https://github.com/im-ian/notion-blog/assets/38205068/56ade899-23bd-4544-8625-154ecad129ae)
 
-Copy [this Notion template](https://imian.notion.site/7cdd2b347b734b7caeb754d8701a4b57?v=c9d11f25b61b4d249d45f3b4dde4c2f2&pvs=4)
+[Notion 템플릿](https://imian.notion.site/7cdd2b347b734b7caeb754d8701a4b57?v=c9d11f25b61b4d249d45f3b4dde4c2f2&pvs=4)을 자기 워크스페이스로 복제합니다.
 
 ![image](https://github.com/im-ian/notion-blog/assets/38205068/0dff2c40-8464-4140-92c2-f865e5067cf2)
 
-Input your ![#f03c15](https://placehold.co/13x13/f03c15/f03c15.png) `NOTION_BLOG_PAGE_ID` and ![#1589F0](https://placehold.co/13x13/1589F0/1589F0.png) `NOTION_VIEW_ID`
+자기 페이지의 ![#f03c15](https://placehold.co/13x13/f03c15/f03c15.png) `NOTION_BLOG_PAGE_ID`와 ![#1589F0](https://placehold.co/13x13/1589F0/1589F0.png) `NOTION_VIEW_ID`를 확인합니다.
 
 ![image](https://github.com/im-ian/notion-blog/assets/38205068/62d3c169-d47b-4e78-80d4-192fe446b1c6)
 
-Add your `env` values in Vercel `Environment Variables`
+Vercel `Environment Variables`에 위 값들을 입력합니다.
 
-If you need sentry debugging, add your sentry configure in environment
+Sentry로 에러를 추적하려면 다음 4개 env를 모두 설정해야 합니다.
+
 - `SENTRY_ORG`
 - `SENTRY_PROJECT`
 - `SENTRY_AUTH_TOKEN`
 - `SENTRY_DSN`
 
-`Sentry.init()` will not proceed unless you add all four Sentry settings.
+4개가 모두 있어야 `Sentry.init()`이 활성화됩니다.
 
 ![image](https://github.com/im-ian/notion-blog/assets/38205068/47731fd6-e4b0-4bfa-a0b4-c9ef9471f409)
 
-Deploy your repository on [Vercel](https://vercel.com/)!
+[Vercel](https://vercel.com/)에 배포하면 끝입니다.
 
 <br />
 
-## 💻 Development
+## 💻 개발
 
 ```shell
 cp .env.example .env
-
 ```
 
-if you try develop this project, copy `.env.example` to `.env` and
+로컬 개발은 `.env.example`을 `.env`로 복사한 뒤 다음을 실행합니다.
 
 ```shell
 yarn && yarn dev
-# or
+# 또는
 npm install && npm dev
 ```
 
 <br />
 
-## 🎨 Customize
+## 🎨 커스터마이징
 
 ```ts
 import type { Config } from "@/types";
 
 const CONFIG: Config = {
-  // Profile
   profile: {
-    // 댓글 기능을 위한 레포명, 입력하지 않으면 댓글 기능이 비활성화됩니다.
+    // 댓글(utterances) 연동용 owner/repo. 미설정 시 댓글 비활성
     repo: "im-ian/notion-blog",
-    // 페이지 상단 Github 아이콘 링크
-    github: "https://github.com/im-ian",
+    github: "im-ian",
   },
   // ...
-}
+};
 ```
-you can customize below information on `site.config.ts` (자세한 옵션 표는 아래 참고)
+
+`site.config.ts`에서 다음 그룹을 조정할 수 있습니다 (자세한 옵션은 아래 표 참고).
+
 - profile
 - notion
 - meta (SEO)
@@ -85,7 +88,6 @@ you can customize below information on `site.config.ts` (자세한 옵션 표는
 - comments
 - rss
 - footer
-- sentry
 
 ### `profile`
 
@@ -117,6 +119,7 @@ you can customize below information on `site.config.ts` (자세한 옵션 표는
 | `true` | Notion에서 만든 view의 결과만 사용. 정렬·필터·hidden 컬럼 모두 view에 따름. viewId가 잘못되면 자동으로 기본 동작으로 fallback (콘솔 경고 출력) |
 
 view를 직접 만들고 싶다면:
+
 1. Notion에서 블로그 DB 우상단 `+` → 새 view 추가 (필터/정렬 자유 설정)
 2. 해당 view를 연 상태에서 URL의 `?v=<viewId>` 부분 복사
 3. `NOTION_VIEW_ID` env에 저장
@@ -124,7 +127,7 @@ view를 직접 만들고 싶다면:
 
 ### `meta`
 
-`Next.js Metadata`를 그대로 받으며 다음 키가 추가됨.
+`Next.js Metadata`를 그대로 받으며 다음 키가 추가됩니다.
 
 | 키 | 타입 | 설명 |
 |----|------|------|
@@ -163,7 +166,7 @@ view를 직접 만들고 싶다면:
 | `useScheduled` | `boolean` | `true` | `true`일 때 Public 포스트가 작성일을 넘어야 리스트에 노출 (예약 게시) |
 | `showSummary` | `boolean` | `true` | 포스트 카드의 summary 노출 |
 | `showPrevNext` | `boolean` | `true` | 포스트 페이지 하단 인접(이전/다음) 포스트 네비게이션 |
-| `dateFormat` | `string` | `"YYYY년 MM월 DD일"` | dayjs 토큰 (e.g. `"YYYY-MM-DD"`, `"YYYY/MM/DD HH:mm"`) |
+| `dateFormat` | `string` | `"YYYY년 MM월 DD일"` | dayjs 토큰 (예: `"YYYY-MM-DD"`, `"YYYY/MM/DD HH:mm"`) |
 | `showScrollProgress` | `boolean` | `true` | 포스트 페이지 상단 스크롤 진행바 |
 
 ### `comments`
@@ -202,14 +205,14 @@ export const vars = createGlobalTheme(":root", {
     "gray-600": "#4b5563",
     "gray-700": "#374151",
     // ...
-  }
+  },
 });
 ```
 
-If you want to edit color or size, edit file `sprinkles.css.ts` or `vars.css.ts`
+색상이나 사이즈를 바꾸려면 `sprinkles.css.ts` 또는 `vars.css.ts`를 수정하세요.
 
 <br />
 
-## 📄 License
+## 📄 라이선스
 
-Released under the [MIT License](./LICENSE). 자유롭게 포크해서 자기 블로그로 사용 가능.
+[MIT 라이선스](./LICENSE) 하에 공개되었습니다. 자유롭게 fork해서 자기 블로그로 사용 가능합니다.


### PR DESCRIPTION
## Summary

기존 README의 한영 혼용을 정리. 한국어 버전을 기본(`README.md`)으로 두고, 영문 버전(`README.en.md`)을 추가. 두 파일 상단에 언어 스위처 라인 배치.

## 변경

- `README.md`: 한국어로 통일 (기본). 옵션 표·가이드·라이선스 섹션 모두 한국어
- `README.en.md`: 신규 영문 버전. 동일 구조/옵션 표를 영문으로 작성
- "간단한 사이트 설정" → "코드 수정 없이 다양한 사이트 옵션 설정" / "Rich site options without touching code"
- 각 README 상단에 `[한국어](./README.md) · [English](./README.en.md)` 스위처

## Test plan

- [x] 두 파일에 빠진 옵션 없음 확인
- [x] 옵션 표 포맷 일치 (키/타입/기본값/설명 동일 컬럼)
- [ ] 사용자 검토: 영문 표현이 어색하거나 한국어와 의미 어긋나는 부분
