### PR TITLE
ci: PR/Issue 작성자 자동 assign workflow 추가

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,28 @@
+name: Auto Assign Author
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign PR/Issue to author
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request_target" ]; then
+            gh pr edit ${{ github.event.pull_request.number }} \
+              --add-assignee ${{ github.event.pull_request.user.login }}
+          else
+            gh issue edit ${{ github.event.issue.number }} \
+              --add-assignee ${{ github.event.issue.user.login }}
+          fi


### PR DESCRIPTION
## Summary

PR/Issue가 새로 열리거나 reopen될 때 작성자를 자동으로 assignee로 등록.

## 동작

- 트리거: `pull_request_target` (opened/reopened) + `issues` (opened/reopened)
- 권한: `pull-requests: write`, `issues: write`
- 액션: `gh pr edit <num> --add-assignee <author>` / `gh issue edit <num> --add-assignee <author>`
- `pull_request_target` 사용으로 fork PR도 권한 확보

## Test plan

- [ ] 머지 후 새 PR 열어 작성자가 assignee로 자동 지정되는지 확인
- [ ] 새 issue 열어 작성자 assignee 자동 지정 확인
